### PR TITLE
Fixed bugs with balance

### DIFF
--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
@@ -218,8 +218,9 @@ namespace Plugin.SimpleAudioPlayer
             balance = Math.Max(-1, balance);
             balance = Math.Min(1, balance);
 
-            var right = (balance < 0) ? volume * -1 * balance : volume;
-            var left = (balance > 0) ? volume * 1 * balance : volume;
+            // Using the "constant power pan rule." See: http://www.rs-met.com/documents/tutorials/PanRules.pdf
+            var left = Math.Cos((Math.PI * (balance + 1)) / 4) * volume;
+            var right = Math.Sin((Math.PI * (balance + 1)) / 4) * volume;
 
             player?.SetVolume((float)left, (float)right);
         }

--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.iOS/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.iOS/SimpleAudioPlayerImplementation.cs
@@ -181,10 +181,8 @@ namespace Plugin.SimpleAudioPlayer
             balance = Math.Max(-1, balance);
             balance = Math.Min(1, balance);
 
-            var right = (balance < 0) ? volume * -1 * balance : volume;
-            var left = (balance > 0) ? volume * 1 * balance : volume;
-
-            player.SetVolume((float)left, (float)right);
+            player.Volume = (float)volume;
+            player.Pan = (float)balance;
         }
         void OnPlaybackEnded()
         {


### PR DESCRIPTION
As per #40 

iOS is straightforward as it provides a Pan property alongside Volume.

Android is more troublesome, it requires math. For android, I used "constant power pan rule." See: http://www.rs-met.com/documents/tutorials/PanRules.pdf

Note that this is not properly tested using the nuget package format. I had difficulty using Visual Studio for Mac to get proper debugging sessions working, so I ended up porting the code directly into my project and testing it there. It does sound good and the pan output is obvious, but I highly recommend that this changeset gets some further testing.

I notice that the iOS version sounds good and loud, but the Android version not nearly as much. Part of the reason for this is that is because the constant power pan rule sets the volume of the nominal (0) setting at 0.7 so there is room to move up when panning to either one of the bias channels. So it is already quieter than playing everything pan 0 with a 1.0 volume. But not only that, the Android emulator that came with Visual Studio for Mac just doesn't seem to punch the sound out the same way the XCode iOS emulator does.

How iOS is doing it I cannot say. I assuming it is all closed proprietary code.