### PR TITLE
Update SimpleAudioPlayerImplementation.cs

### DIFF
--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
@@ -214,7 +214,7 @@ namespace Plugin.SimpleAudioPlayer
         public void Seek(double position)
         {
 	    if(CanSeek)
-            	player?.SeekTo((int)position*1000);
+            	player?.SeekTo((int)(position * 1000D));
         }
 
         ///<Summary>


### PR DESCRIPTION
Hi, there's a problem with the casting when performing a seek operation (on the Android implementation). The double value is cast to an int and then multiplied by 1000 in order to convert it to milliseconds, however, the current code truncates the position value (due to the typecast). I've corrected this by ensuring the multiplication is done using doubles & then the resultant double value is cast to an int.

Thanks! 