### PR TITLE
Invoke PlaybackEnded event when calling Stop()

### DIFF
--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Android/SimpleAudioPlayerImplementation.cs
@@ -1,4 +1,4 @@
-using Android.Content.Res;
+﻿using Android.Content.Res;
 using System;
 using System.IO;
 using Uri = Android.Net.Uri;
@@ -193,11 +193,12 @@ namespace Plugin.SimpleAudioPlayer
         ///</Summary>
         public void Stop()
         {
-	    if(!IsPlaying)
-	    	return;
+	        if(!IsPlaying)
+	    	    return;
 		
             Pause();
             Seek(0);
+            PlaybackEnded?.Invoke(this, EventArgs.Empty);
         }
 
         ///<Summary>

--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Tizen/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.Tizen/SimpleAudioPlayerImplementation.cs
@@ -178,6 +178,7 @@ namespace Plugin.SimpleAudioPlayer
 					{
 						player.Stop();
 						await SeekToAsync((int)CurrentPosition);
+						PlaybackEnded?.Invoke(this, EventArgs.Empty);
 					}
 				}
 				else

--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.UWP/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.UWP/SimpleAudioPlayerImplementation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Windows.Media.Core;
 using Windows.Media.Playback;
@@ -168,6 +168,7 @@ namespace Plugin.SimpleAudioPlayer
             {
                 Pause();
                 Seek(0);
+                PlaybackEnded?.Invoke(this, EventArgs.Empty);
             }
         }
 

--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.WPF/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.WPF/SimpleAudioPlayerImplementation.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Windows.Media;
 
@@ -161,6 +161,7 @@ namespace Plugin.SimpleAudioPlayer
         {
             Pause();
             Seek(0);
+            PlaybackEnded?.Invoke(this, EventArgs.Empty);
         }
 
         ///<Summary>

--- a/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.iOS/SimpleAudioPlayerImplementation.cs
+++ b/SimpleAudioPlayer/SimpleAudioPlayer/Plugin.SimpleAudioPlayer.iOS/SimpleAudioPlayerImplementation.cs
@@ -1,4 +1,4 @@
-using AVFoundation;
+﻿using AVFoundation;
 using Foundation;
 using System;
 using System.IO;
@@ -158,6 +158,7 @@ namespace Plugin.SimpleAudioPlayer
         {
             player?.Stop();
             Seek(0);
+            PlaybackEnded?.Invoke(this, EventArgs.Empty);
         }
 
         ///<Summary>


### PR DESCRIPTION
Calling Stop() will end the playback, so the PlaybackEnded event should fire.